### PR TITLE
Migrate to DeepL Java client library

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,9 +50,7 @@ repositories {
 }
 
 dependencies {
-    // JSON parser
-    implementation(libs.jackson.core)
-    implementation(libs.jackson.databind)
+    packIntoJar("com.deepl.api:deepl-java:1.9.0")
 
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.wiremock)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,11 @@
 [versions]
 slf4j = "2.0.7"
 junit5 = "5.12.0"
-jackson = "2.16.1"
 wiremock = "3.12.1"
 
 [libraries]
 slf4j-simple = {group = "org.slf4j", name = "slf4j-simple",  version.ref = "slf4j"}
 junit-jupiter = {group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit5"}
-jackson-core = {group = "com.fasterxml.jackson.core", name = "jackson-core", version.ref = "jackson"}
-jackson-databind = {group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson"}
 wiremock = {group = "org.wiremock", name = "wiremock", version.ref = "wiremock"}
 
 [plugins]

--- a/src/main/resources/org/omegat/machinetranslators/deepl/DeepLBundle.properties
+++ b/src/main/resources/org/omegat/machinetranslators/deepl/DeepLBundle.properties
@@ -25,8 +25,6 @@
 
 MT_ENGINE_DEEPL=DeepL
 
-MT_JSON_ERROR=Error while reading MT result
-MT_JSON_PARSE_ERROR=JSON parse error while reading MT result
 MT_ENGINE_DEEPL_API_KEY_LABEL=API key:
 DEEPL_API_KEY_NOTFOUND=DeepL API key not available. See the user manual for instructions.
 DEEPL_CONNECTION_ERROR=DeepL connector library report connection error.

--- a/src/test/java/org/omegat/machinetranslators/deepl/DeepLTranslate2Test.java
+++ b/src/test/java/org/omegat/machinetranslators/deepl/DeepLTranslate2Test.java
@@ -27,7 +27,6 @@ package org.omegat.machinetranslators.deepl;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -79,21 +78,6 @@ public class DeepLTranslate2Test {
     }
 
     @Test
-    void testGetJsonResults() throws Exception {
-        DeepLTranslate2 deepLTranslate = new DeepLTranslate2TestStub();
-        String json = "{ \"translations\": [ { \"detected_source_language\": \"DE\", \"text\": \"Hello World!\" } ] }";
-        String result = deepLTranslate.getJsonResults(json);
-        assertEquals("Hello World!", result);
-    }
-
-    @Test
-    void testGetJsonResultsWithWrongJson() {
-        DeepLTranslate2 deepLTranslate = new DeepLTranslate2TestStub();
-        String json = "{ \"response\": \"failed\" }";
-        assertThrows(Exception.class, () -> deepLTranslate.getJsonResults(json));
-    }
-
-    @Test
     void testResponse(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
         String key = "deepl8api8key";
 
@@ -115,15 +99,11 @@ public class DeepLTranslate2Test {
         String url = String.format("http://localhost:%d", port);
         String sourceText = "source text";
         DeepLTranslate2 deepLTranslate = new DeepLTranslate2TestStub(url, key);
-        String result = deepLTranslate.translate(new Language("DE"), new Language("EN"), sourceText);
+        String result = deepLTranslate.translate(new Language("de-DE"), new Language("en-US"), sourceText);
         assertEquals("Hello World!", result);
     }
 
     static class DeepLTranslate2TestStub extends DeepLTranslate2 {
-
-        DeepLTranslate2TestStub() {
-            super("", "key");
-        }
 
         DeepLTranslate2TestStub(String url, String key) {
             super(url, key);


### PR DESCRIPTION
Replaced manual HTTP requests with the official DeepL Java client library for improved maintainability and functionality. Updated tests, dependencies, and class structure accordingly, and adjusted language codes and configurations to match the new implementation.